### PR TITLE
chore: Taskfileのサポート

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,59 @@
+version: '3'
+silent: true
+
+# docker-compose派とdocker compose派のどちらにも対応する
+vars:
+  COMPOSE_CMD:
+    sh: |
+      if command -v docker compose >/dev/null 2>&1; then
+        echo "docker compose"
+      elif command -v docker-compose >/dev/null 2>&1; then
+        echo "docker-compose"
+      else
+        echo "docker compose"
+      fi
+
+includes:
+  web:
+    dir: ./web
+    taskfile: ./taskfile/Taskfile.web.yml
+
+  server:
+    dir: ./server
+    taskfile: ./taskfile/Taskfile.server.yml
+
+  db:
+    dir: ./db
+    taskfile: ./taskfile/Taskfile.db.yml
+    flatten: true
+
+tasks:
+  default:
+    desc: List all tasks
+    aliases:
+      - list
+    cmd: task -l
+
+  up:
+    desc: Up docker
+    cmds:
+     - "{{.COMPOSE_CMD}} up -d"
+
+  down:
+    desc: Down docker
+    cmd: "{{.COMPOSE_CMD}} down"
+
+  test:
+    deps:
+      - task: server:test
+
+  dev:
+    desc: Start dev server
+    deps:
+      - task: web:dev
+      - task: server:dev
+
+  install:
+    desc: Install dependencies
+    deps:
+      - task: web:install

--- a/taskfile/Taskfile.db.yml
+++ b/taskfile/Taskfile.db.yml
@@ -1,0 +1,23 @@
+version: '3'
+silent: true
+
+tasks:
+  migrate:run:
+    desc: Run migration
+    cmd: sqlx migrate run
+
+  migrate:revert:
+    desc: Revert migration
+    cmd: sqlx migrate revert
+
+  migrate:add:
+    desc: Add migration
+    cmd: sqlx migrate add -r {{.CLI_ARGS}} 
+
+  db:create:
+    desc: Create database
+    cmd: sqlx database create
+
+  db:drop:
+    desc: Drop database
+    cmd: sqlx database drop

--- a/taskfile/Taskfile.server.yml
+++ b/taskfile/Taskfile.server.yml
@@ -1,0 +1,15 @@
+version: '3'
+silent: true
+
+tasks:
+  default:
+    desc: List for server
+    cmd: "task -l | grep server:"
+
+  dev:
+    desc: Start backend server
+    cmd: cargo run
+
+  test:
+    desc: Run server test
+    cmd: cargo test --workspace

--- a/taskfile/Taskfile.web.yml
+++ b/taskfile/Taskfile.web.yml
@@ -1,0 +1,41 @@
+version: '3'
+silent: true
+
+tasks:
+  default:
+    desc: List for web
+    cmd: "task -l | grep web:"
+
+  dev:
+    desc: Start web server
+    deps:
+      - install
+    cmd: pnpm dev
+
+  install:
+    desc: Install dependencies
+    cmd: pnpm install --frozen-lockfile
+
+  format:
+    desc: Run format
+    cmd: pnpm biome format
+
+  format-w:
+    desc: Run format and write
+    cmd: pnpm biome format --write
+
+  lint:
+    desc: Run lint
+    cmd: pnpm biome lint
+
+  lint-w:
+    desc: Run lint
+    cmd: pnpm biome lint --apply
+
+  check:
+    desc: Run biome check
+    cmd: pnpm biome check
+
+  check-w:
+    desc: Run biome check with --write
+    cmd: pnpm biome check --write


### PR DESCRIPTION
## issueリンク

#36 

## 依存関係あり
#24 が承認されるまでこのプルリクを承認しないでください

## 概要
Taskfileが使えるようになりました。

- Database
- Docker
- Lint / Format
- Test

の操作に対応してます。

タスク一覧は
```
$ task
```
で見れます。

その他，
```
$ task web
$ task server
```
でもぞれぞれに属するタスクが見れます。
( `grep` コマンドに依存しています )
