### PR TITLE
feat: roomのDBロジックを実装

### DIFF
--- a/server/db/src/lib.rs
+++ b/server/db/src/lib.rs
@@ -1,4 +1,5 @@
 mod message;
+mod room;
 mod user;
 
 use sqlx::{

--- a/server/db/src/room.rs
+++ b/server/db/src/room.rs
@@ -1,0 +1,136 @@
+use crate::DB;
+use sqlx::types::chrono::{DateTime, Utc};
+
+impl DB {
+    pub async fn add_room(&mut self, user: models::Room) -> Result<(), sqlx::Error> {
+        let id = user.id;
+        let creator_id = user.creator_id;
+        let url = user.url;
+        let expired_at = user.expired_at;
+        let created_at = user.created_at;
+
+        let query = sqlx::query!(
+            "INSERT INTO rooms (id, creator_id, url, expired_at, created_at) VALUES (?, ?, ?, ?, ?)",
+            id,
+            creator_id,
+            url,
+            expired_at,
+            created_at
+        );
+
+        self.execute(query).await?;
+
+        Ok(())
+    }
+
+    pub async fn remove_room(&mut self, room_id: &str) -> Result<(), sqlx::Error> {
+        let query = sqlx::query!("DELETE FROM rooms WHERE id = ?", room_id);
+
+        self.execute(query).await?;
+
+        Ok(())
+    }
+
+    pub async fn update_room(
+        &mut self,
+        room_id: &str,
+        creator_id: Option<Option<&str>>,
+        expired_at: Option<DateTime<Utc>>,
+    ) -> Result<(), sqlx::Error> {
+        if let Some(creator_id) = creator_id {
+            let query = sqlx::query!(
+                "UPDATE rooms SET creator_id = ? WHERE id = ?",
+                creator_id,
+                room_id
+            );
+            self.execute(query).await?;
+        }
+
+        if let Some(expired_at) = expired_at {
+            let query = sqlx::query!(
+                "UPDATE rooms SET expired_at = ? WHERE id = ?",
+                expired_at,
+                room_id
+            );
+            self.execute(query).await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn get_room(&self, room_id: &str) -> Result<models::Room, sqlx::Error> {
+        let room = sqlx::query_as(
+            "SELECT id, creator_id, url, expired_at, created_at FROM rooms WHERE id = ?",
+        )
+        .bind(room_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(room)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::DB;
+    use sqlx::{
+        types::chrono::{TimeZone, Utc},
+        MySqlPool,
+    };
+
+    #[sqlx::test(migrations = "../../db/migrations", fixtures("user"))]
+    pub async fn add_room_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
+        dotenvy::dotenv().unwrap();
+
+        let mut db = DB::from_pool(pool);
+
+        db.add_room(models::Room {
+            id: "sample".to_owned(),
+            creator_id: Some("0".to_owned()),
+            url: "url".to_owned(),
+            expired_at: None,
+            created_at: Utc::now(),
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrations = "../../db/migrations", fixtures("user", "room"))]
+    pub async fn get_room_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
+        dotenvy::dotenv().unwrap();
+
+        let db = DB::from_pool(pool);
+        let _ = db.get_room("0").await?;
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrations = "../../db/migrations", fixtures("user", "room"))]
+    pub async fn remove_room_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
+        dotenvy::dotenv().unwrap();
+
+        let mut db = DB::from_pool(pool);
+        db.remove_room("0").await?;
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrations = "../../db/migrations", fixtures("user", "room"))]
+    pub async fn update_room_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
+        dotenvy::dotenv().unwrap();
+
+        let date = Utc.with_ymd_and_hms(2021, 1, 1, 0, 0, 0).unwrap();
+        let mut db = DB::from_pool(pool);
+        db.update_room("0", None, Some(date)).await?;
+        let room = db.get_room("0").await?;
+        assert_eq!(room.expired_at, Some(date));
+
+        db.update_room("0", Some(None), None).await?;
+        let room = db.get_room("0").await?;
+        assert_eq!(room.creator_id, None);
+        assert_eq!(room.expired_at, Some(date));
+
+        Ok(())
+    }
+}

--- a/server/models/src/lib.rs
+++ b/server/models/src/lib.rs
@@ -9,6 +9,15 @@ pub struct User {
 }
 
 #[derive(sqlx::FromRow)]
+pub struct Room {
+    pub id: String,
+    pub creator_id: Option<String>,
+    pub url: String,
+    pub expired_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(sqlx::FromRow)]
 pub struct Message {
     pub id: String,
     pub room_id: String,


### PR DESCRIPTION
## issueリンク

#50 

## 概要
チャットルームのデータベース編集用に
- add_room
- update_room
- get_room
- remove_room
の関数を実装し、テストも実装しました。
