### PR TITLE
feat: participantのDBロジックを実装

### DIFF
--- a/server/db/src/fixtures/participant.sql
+++ b/server/db/src/fixtures/participant.sql
@@ -1,0 +1,3 @@
+INSERT INTO participants (room_id, user_id, joined_at) VALUES (
+    '0', '0', DEFAULT
+)

--- a/server/db/src/lib.rs
+++ b/server/db/src/lib.rs
@@ -1,4 +1,5 @@
 mod message;
+mod participants;
 mod user;
 
 use sqlx::{

--- a/server/db/src/participants.rs
+++ b/server/db/src/participants.rs
@@ -1,0 +1,97 @@
+use crate::DB;
+
+impl DB {
+    pub async fn add_participant(&mut self, user: models::Participant) -> Result<(), sqlx::Error> {
+        let room_id = user.room_id;
+        let user_id = user.user_id;
+        let joined_at = user.joined_at;
+
+        let query = sqlx::query!(
+            "INSERT INTO participants (room_id, user_id, joined_at) VALUES (?, ?, ?)",
+            room_id,
+            user_id,
+            joined_at
+        );
+
+        self.execute(query).await?;
+
+        Ok(())
+    }
+
+    pub async fn remove_participant(
+        &mut self,
+        room_id: &str,
+        user_id: &str,
+    ) -> Result<(), sqlx::Error> {
+        let query = sqlx::query!(
+            "DELETE FROM participants WHERE room_id = ? AND user_id = ?",
+            room_id,
+            user_id
+        );
+
+        self.execute(query).await?;
+
+        Ok(())
+    }
+
+    pub async fn get_participant(
+        &self,
+        room_id: &str,
+        user_id: &str,
+    ) -> Result<models::Participant, sqlx::Error> {
+        let participant = sqlx::query_as(
+            "SELECT room_id, user_id, joined_at FROM participants WHERE room_id = ? AND user_id = ?",
+        )
+        .bind(room_id)
+        .bind(user_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(participant)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::DB;
+    use sqlx::{types::chrono::Utc, MySqlPool};
+
+    #[sqlx::test(migrations = "../../db/migrations", fixtures("user", "room"))]
+    pub async fn add_participant_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
+        dotenvy::dotenv().unwrap();
+
+        let mut db = DB::from_pool(pool);
+
+        db.add_participant(models::Participant {
+            room_id: "0".to_owned(),
+            user_id: "0".to_owned(),
+            joined_at: Utc::now(),
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    #[sqlx::test(
+        migrations = "../../db/migrations",
+        fixtures("user", "room", "participant")
+    )]
+    pub async fn get_participant_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
+        dotenvy::dotenv().unwrap();
+
+        let db = DB::from_pool(pool);
+        let _ = db.get_participant("0", "0").await?;
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrations = "../../db/migrations", fixtures("user", "room"))]
+    pub async fn remove_participant_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
+        dotenvy::dotenv().unwrap();
+
+        let mut db = DB::from_pool(pool);
+        db.remove_participant("0", "0").await?;
+
+        Ok(())
+    }
+}

--- a/server/models/src/lib.rs
+++ b/server/models/src/lib.rs
@@ -9,6 +9,13 @@ pub struct User {
 }
 
 #[derive(sqlx::FromRow)]
+pub struct Participant {
+    pub room_id: String,
+    pub user_id: String,
+    pub joined_at: DateTime<Utc>,
+}
+
+#[derive(sqlx::FromRow)]
 pub struct Message {
     pub id: String,
     pub room_id: String,


### PR DESCRIPTION
## issueリンク

#51 

## 概要
ルーム参加者のデータベース編集用に
- add_participant
- get_participant
- remove_participant
の関数を実装し、テストも実装しました。