### PR TITLE
chore: Dopplerを使った環境変数共有に対応

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,6 +6,7 @@ dotenv:
 
 # docker-compose派とdocker compose派のどちらにも対応する
 vars:
+  DOPPLER_CMD: doppler run --
   COMPOSE_CMD:
     sh: |
       if command -v docker compose >/dev/null 2>&1; then
@@ -40,7 +41,7 @@ tasks:
   up:
     desc: Up docker
     cmds:
-     - "{{.COMPOSE_CMD}} up -d"
+     - "{{.DOPPLER_CMD}} {{.COMPOSE_CMD}} up -d"
 
   down:
     desc: Down docker
@@ -64,3 +65,8 @@ tasks:
   ngrok:
     desc: Start ngrok tunnel
     cmd: ngrok http --domain={{.NGROK_DOMAIN}} 3050
+  
+  nvim:
+    desc: Nvim with env
+    cmd: "{{.DOPPLER_CMD}} nvim"
+

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,7 +6,13 @@ dotenv:
 
 # docker-compose派とdocker compose派のどちらにも対応する
 vars:
-  DOPPLER_CMD: doppler run --
+  DOPPLER_CMD:
+    sh: |
+      if command -v doppler >/dev/null 2>&1; then
+        echo "doppler run --"
+      else
+        echo ""
+      fi
   COMPOSE_CMD:
     sh: |
       if command -v docker compose >/dev/null 2>&1; then

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -256,7 +256,6 @@ dependencies = [
  "chrono",
  "clerk-rs",
  "db",
- "dotenvy",
  "models",
  "parking_lot",
  "rand 0.9.0",
@@ -438,7 +437,6 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 name = "db"
 version = "0.1.0"
 dependencies = [
- "dotenvy",
  "models",
  "sqlx",
  "tokio",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,5 +10,4 @@ edition = "2021"
 
 [workspace.dependencies]
 chrono = "0.4.39"
-dotenvy = "0.15.7"
 tokio = "1.43.0"

--- a/server/chat/Cargo.toml
+++ b/server/chat/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-dotenvy.workspace = true
 axum = { version = "0.8.1", features = ["ws", "macros"] }
 tokio = { version = "1.43.0", features = ["full"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/server/chat/src/main.rs
+++ b/server/chat/src/main.rs
@@ -30,8 +30,6 @@ impl AppState {
 
 #[tokio::main]
 async fn main() {
-    dotenvy::dotenv().unwrap();
-
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()

--- a/server/db/Cargo.toml
+++ b/server/db/Cargo.toml
@@ -13,4 +13,3 @@ sqlx = { version = "0.8.3", features = [
   "migrate",
 ] }
 tokio = { workspace = true, features = ["macros"] }
-dotenvy.workspace = true

--- a/server/db/src/message.rs
+++ b/server/db/src/message.rs
@@ -70,8 +70,6 @@ mod test {
 
     #[sqlx::test(migrations = "../../db/migrations", fixtures("user", "room"))]
     pub async fn add_message_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
-        dotenvy::dotenv().unwrap();
-
         let mut db = DB::from_pool(pool);
 
         db.add_message(models::Message {
@@ -92,8 +90,6 @@ mod test {
         fixtures("user", "room", "message")
     )]
     pub async fn get_message_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
-        dotenvy::dotenv().unwrap();
-
         let db = DB::from_pool(pool);
         let _ = db.get_message("0").await?;
 
@@ -105,8 +101,6 @@ mod test {
         fixtures("user", "room", "message")
     )]
     pub async fn remove_message_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
-        dotenvy::dotenv().unwrap();
-
         let mut db = DB::from_pool(pool);
         db.remove_message("0").await?;
 
@@ -118,8 +112,6 @@ mod test {
         fixtures("user", "room", "message")
     )]
     pub async fn update_message_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
-        dotenvy::dotenv().unwrap();
-
         let mut db = DB::from_pool(pool);
         db.update_message("0", None, Some("changed-message"))
             .await?;

--- a/server/db/src/participants.rs
+++ b/server/db/src/participants.rs
@@ -58,8 +58,6 @@ mod test {
 
     #[sqlx::test(migrations = "../../db/migrations", fixtures("user", "room"))]
     pub async fn add_participant_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
-        dotenvy::dotenv().unwrap();
-
         let mut db = DB::from_pool(pool);
 
         db.add_participant(models::Participant {
@@ -77,8 +75,6 @@ mod test {
         fixtures("user", "room", "participant")
     )]
     pub async fn get_participant_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
-        dotenvy::dotenv().unwrap();
-
         let db = DB::from_pool(pool);
         let _ = db.get_participant("0", "0").await?;
 
@@ -87,8 +83,6 @@ mod test {
 
     #[sqlx::test(migrations = "../../db/migrations", fixtures("user", "room"))]
     pub async fn remove_participant_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
-        dotenvy::dotenv().unwrap();
-
         let mut db = DB::from_pool(pool);
         db.remove_participant("0", "0").await?;
 

--- a/server/db/src/room.rs
+++ b/server/db/src/room.rs
@@ -80,8 +80,6 @@ mod test {
 
     #[sqlx::test(migrations = "../../db/migrations", fixtures("user"))]
     pub async fn add_room_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
-        dotenvy::dotenv().unwrap();
-
         let mut db = DB::from_pool(pool);
 
         db.add_room(models::Room {
@@ -98,8 +96,6 @@ mod test {
 
     #[sqlx::test(migrations = "../../db/migrations", fixtures("user", "room"))]
     pub async fn get_room_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
-        dotenvy::dotenv().unwrap();
-
         let db = DB::from_pool(pool);
         let _ = db.get_room("0").await?;
 
@@ -108,8 +104,6 @@ mod test {
 
     #[sqlx::test(migrations = "../../db/migrations", fixtures("user", "room"))]
     pub async fn remove_room_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
-        dotenvy::dotenv().unwrap();
-
         let mut db = DB::from_pool(pool);
         db.remove_room("0").await?;
 
@@ -118,8 +112,6 @@ mod test {
 
     #[sqlx::test(migrations = "../../db/migrations", fixtures("user", "room"))]
     pub async fn update_room_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
-        dotenvy::dotenv().unwrap();
-
         let date = Utc.with_ymd_and_hms(2021, 1, 1, 0, 0, 0).unwrap();
         let mut db = DB::from_pool(pool);
         db.update_room("0", None, Some(date)).await?;

--- a/server/db/src/user.rs
+++ b/server/db/src/user.rs
@@ -71,8 +71,6 @@ mod test {
 
     #[sqlx::test(migrations = "../../db/migrations")]
     pub async fn add_user_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
-        dotenvy::dotenv().unwrap();
-
         let mut db = DB::from_pool(pool);
 
         db.add_user(models::User {
@@ -88,8 +86,6 @@ mod test {
 
     #[sqlx::test(migrations = "../../db/migrations", fixtures("user"))]
     pub async fn get_user_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
-        dotenvy::dotenv().unwrap();
-
         let db = DB::from_pool(pool);
         let _ = db.get_user("0").await?;
 
@@ -98,8 +94,6 @@ mod test {
 
     #[sqlx::test(migrations = "../../db/migrations", fixtures("user"))]
     pub async fn remove_user_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
-        dotenvy::dotenv().unwrap();
-
         let mut db = DB::from_pool(pool);
         db.remove_user("0").await?;
 
@@ -108,8 +102,6 @@ mod test {
 
     #[sqlx::test(migrations = "../../db/migrations", fixtures("user"))]
     pub async fn update_user_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
-        dotenvy::dotenv().unwrap();
-
         let mut db = DB::from_pool(pool);
         db.update_user("0", Some("changed-user"), None).await?;
 

--- a/taskfile/Taskfile.db.yml
+++ b/taskfile/Taskfile.db.yml
@@ -4,23 +4,23 @@ silent: true
 tasks:
   migrate:run:
     desc: Run migration
-    cmd: sqlx migrate run
+    cmd: "{{.DOPPLER_CMD}} sqlx migrate run"
 
   migrate:revert:
     desc: Revert migration
-    cmd: sqlx migrate revert
+    cmd: "{{.DOPPLER_CMD}} sqlx migrate revert"
 
   migrate:add:
     desc: Add migration
-    cmd: sqlx migrate add -r {{.CLI_ARGS}} 
+    cmd: "{{.DOPPLER_CMD}} sqlx migrate add -r {{.CLI_ARGS}}"
 
   db:create:
     desc: Create database
-    cmd: sqlx database create
+    cmd: "{{.DOPPLER_CMD}} sqlx database create"
 
   db:drop:
     desc: Drop database
-    cmd: sqlx database drop
+    cmd: "{{.DOPPLER_CMD}} sqlx database drop"
 
   db:refresh:
     desc: Refresh database

--- a/taskfile/Taskfile.server.yml
+++ b/taskfile/Taskfile.server.yml
@@ -1,7 +1,6 @@
 version: '3'
 silent: true
 
-
 tasks:
   default:
     desc: List for server
@@ -9,8 +8,8 @@ tasks:
 
   dev:
     desc: Start backend server
-    cmd: cargo run
+    cmd: "{{.DOPPLER_CMD}} cargo run"
 
   test:
     desc: Run server test
-    cmd: cargo test --workspace
+    cmd: "{{.DOPPLER_CMD}} cargo test --workspace"

--- a/taskfile/Taskfile.web.yml
+++ b/taskfile/Taskfile.web.yml
@@ -10,32 +10,32 @@ tasks:
     desc: Start web server
     deps:
       - install
-    cmd: pnpm dev
+    cmd: "{{.DOPPLER_CMD}} pnpm dev"
 
   install:
     desc: Install dependencies
-    cmd: pnpm install --frozen-lockfile
+    cmd: "{{.DOPPLER_CMD}} pnpm install --frozen-lockfile"
 
   format:
     desc: Run format
-    cmd: pnpm biome format
+    cmd: "{{.DOPPLER_CMD}} pnpm biome format"
 
   format-w:
     desc: Run format and write
-    cmd: pnpm biome format --write
+    cmd: "{{.DOPPLER_CMD}} pnpm biome format --write"
 
   lint:
     desc: Run lint
-    cmd: pnpm biome lint
+    cmd: "{{.DOPPLER_CMD}} pnpm biome lint"
 
   lint-w:
     desc: Run lint
-    cmd: pnpm biome lint --apply
+    cmd: "{{.DOPPLER_CMD}} pnpm biome lint --apply"
 
   check:
     desc: Run biome check
-    cmd: pnpm biome check
+    cmd: "{{.DOPPLER_CMD}} pnpm biome check"
 
   check-w:
     desc: Run biome check with --write
-    cmd: pnpm biome check --write
+    cmd: "{{.DOPPLER_CMD}} pnpm biome check --write"


### PR DESCRIPTION
## issueリンク

#73 

## 概要
[Doppler](https://www.doppler.com/) を使って環境変数が共有できるようになった。

バックはそれに伴い，dotenvyを廃止した。

### Doppler設定方法
https://docs.doppler.com/docs/cli に従って進る。
1. Doppler CLIのインストール
2. ` $ doppler login` を実行
3. ` $ doppler setup` を実行

### 各エディタのセットアップ方法
https://docs.doppler.com/docs/editors-vs-code に沿って進める

#### Neovim民への注意
DopplerはNvim用のプラグインを提供していないので，別途設定が必要。
( 今まで通りnvimで起動するとdopplerの環境変数が聞かず，sqlx`でDATABASE_URL`が見つからないとエラーが出る。)

TaskfileにDopplerを適応したnvimを起動するコマンドを追加した。
```
$ task nvim
```

その他各Shell環境のDoppler設定ファイルはこちら👇️
https://github.com/crcrworks/nvim-for-doppler