### PR TITLE
feat: 最新のメッセージを個数付きで取得するメソッドを追加

### DIFF
--- a/core/db/src/fixtures/message.sql
+++ b/core/db/src/fixtures/message.sql
@@ -2,5 +2,5 @@
 INSERT INTO messages (
     id, user_id, room_id, content, reply_to_id, created_at
 ) VALUES (
-    '0', '0', '0', 'hero~', NULL, DEFAULT
+    '0', '0', '0', 'hero~', NULL, NOW()
 )

--- a/core/db/src/fixtures/messages_for_reply.sql
+++ b/core/db/src/fixtures/messages_for_reply.sql
@@ -1,0 +1,12 @@
+INSERT INTO messages (
+    id, user_id, room_id, content, reply_to_id, created_at
+) VALUES
+(
+    '0', '0', '0', 'hello', NULL, NOW() - INTERVAL 5 HOUR
+),
+(
+    '1', '0', '0', 'hello', NULL, NOW() - INTERVAL 5 HOUR
+),
+(
+    '2', '0', '0', 'reply to first', '0', NOW()
+)

--- a/core/db/src/fixtures/participant.sql
+++ b/core/db/src/fixtures/participant.sql
@@ -1,3 +1,3 @@
 INSERT INTO participants (room_id, user_id, joined_at) VALUES (
-    '0', '0', DEFAULT
+    '0', '0', NOW()
 )

--- a/core/db/src/fixtures/room.sql
+++ b/core/db/src/fixtures/room.sql
@@ -1,5 +1,5 @@
 INSERT INTO rooms (
     id, room_name, creator_id, url, expired_at, created_at
 ) VALUES (
-    '0', 'sample', '0', 'url', NULL, DEFAULT
+    '0', 'sample', '0', 'url', NULL, NOW()
 )

--- a/core/db/src/fixtures/user.sql
+++ b/core/db/src/fixtures/user.sql
@@ -1,7 +1,7 @@
 INSERT INTO users (id, nickname, introduction, created_at) VALUES (
-    '0', 'John Smith Jonson', NULL, DEFAULT
+    '0', 'John Smith Jonson', NULL, NOW()
 );
 
 INSERT INTO users (id, nickname, introduction, created_at) VALUES (
-    '1', 'Jane Doe', NULL, DEFAULT
+    '1', 'Jane Doe', NULL, NOW()
 )

--- a/core/db/src/message.rs
+++ b/core/db/src/message.rs
@@ -1,5 +1,60 @@
 use crate::DB;
 use models::MessageUpdate;
+use sqlx::types::chrono::{DateTime, Utc};
+
+#[derive(sqlx::FromRow)]
+pub struct MessageWithReply {
+    pub message_id: String,
+    pub message_user_id: Option<String>,
+    pub message_room_id: String,
+    pub message_content: String,
+    pub message_reply_to_id: Option<String>,
+    pub message_created_at: DateTime<Utc>,
+    pub reply_message_id: Option<String>,
+    pub reply_message_user_id: Option<String>,
+    pub reply_message_room_id: Option<String>,
+    pub reply_message_content: Option<String>,
+    pub reply_message_reply_to_id: Option<String>,
+    pub reply_message_created_at: Option<DateTime<Utc>>,
+}
+
+impl MessageWithReply {
+    pub fn into_message_pair(self) -> (models::Message, Option<models::Message>) {
+        let message = models::Message {
+            id: self.message_id,
+            user_id: self.message_user_id,
+            room_id: self.message_room_id,
+            content: self.message_content,
+            reply_to_id: self.message_reply_to_id,
+            created_at: self.message_created_at,
+        };
+        let reply_message = if let Some(reply_message_id) = self.reply_message_id {
+            if let (
+                Some(reply_message_room_id),
+                Some(reply_message_content),
+                Some(reply_message_created_at),
+            ) = (
+                self.reply_message_room_id,
+                self.reply_message_content,
+                self.reply_message_created_at,
+            ) {
+                Some(models::Message {
+                    id: reply_message_id,
+                    user_id: self.reply_message_user_id,
+                    room_id: reply_message_room_id,
+                    content: reply_message_content,
+                    reply_to_id: self.reply_message_reply_to_id,
+                    created_at: reply_message_created_at,
+                })
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        (message, reply_message)
+    }
+}
 
 impl DB {
     pub async fn add_message(&mut self, message: models::Message) -> Result<(), sqlx::Error> {
@@ -68,6 +123,86 @@ impl DB {
         .await?;
 
         Ok(message)
+    }
+
+    pub async fn get_latest_messages(
+        &self,
+        room_id: &str,
+        limit: u32,
+    ) -> Result<Vec<(models::Message, Option<models::Message>)>, sqlx::Error> {
+        let messages_with_reply = sqlx::query_as!(
+            MessageWithReply,
+            r#"
+            SELECT
+                m1.id AS message_id,
+                m1.user_id AS message_user_id,
+                m1.room_id AS message_room_id,
+                m1.content AS message_content,
+                m1.reply_to_id AS message_reply_to_id,
+                m1.created_at AS message_created_at,
+                m2.id AS reply_message_id,
+                m2.user_id AS reply_message_user_id,
+                m2.room_id AS reply_message_room_id,
+                m2.content AS reply_message_content,
+                m2.reply_to_id AS reply_message_reply_to_id,
+                m2.created_at AS reply_message_created_at
+            FROM messages m1
+            LEFT JOIN messages m2 ON m1.reply_to_id = m2.id
+            WHERE m1.room_id = ?
+            ORDER BY m1.created_at DESC
+            LIMIT ?
+            "#,
+            room_id,
+            limit
+        )
+        .fetch_all(&self.pool)
+        .await?
+        .into_iter()
+        .map(|row| row.into_message_pair())
+        .collect();
+
+        Ok(messages_with_reply)
+    }
+
+    pub async fn get_older_messages(
+        &self,
+        room_id: &str,
+        last_created_at: DateTime<Utc>,
+        limit: u32,
+    ) -> Result<Vec<(models::Message, Option<models::Message>)>, sqlx::Error> {
+        let messages_with_reply = sqlx::query_as!(
+            MessageWithReply,
+            r#"
+            SELECT
+                m1.id AS message_id,
+                m1.user_id AS message_user_id,
+                m1.room_id AS message_room_id,
+                m1.content AS message_content,
+                m1.reply_to_id AS message_reply_to_id,
+                m1.created_at AS message_created_at,
+                m2.id AS reply_message_id,
+                m2.user_id AS reply_message_user_id,
+                m2.room_id AS reply_message_room_id,
+                m2.content AS reply_message_content,
+                m2.reply_to_id AS reply_message_reply_to_id,
+                m2.created_at AS reply_message_created_at
+            FROM messages m1
+            LEFT JOIN messages m2 ON m1.reply_to_id = m2.id
+            WHERE m1.room_id = ? AND m1.created_at < ?
+            ORDER BY m1.created_at DESC
+            LIMIT ?
+            "#,
+            room_id,
+            last_created_at,
+            limit
+        )
+        .fetch_all(&self.pool)
+        .await?
+        .into_iter()
+        .map(|row| row.into_message_pair())
+        .collect();
+
+        Ok(messages_with_reply)
     }
 }
 
@@ -144,6 +279,45 @@ mod test {
         let message = db.get_message("0").await?;
         assert_eq!(message.user_id, None);
         assert_eq!(message.content, "changed-message");
+
+        Ok(())
+    }
+
+    #[sqlx::test(
+        migrations = "../../db/migrations",
+        fixtures("user", "room", "messages_for_reply")
+    )]
+    pub async fn get_latest_messages_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
+        let db = DB::from_pool(pool);
+        let room_id = "0";
+        let limit = 20;
+        let latest_messages = db.get_latest_messages(room_id, limit).await?;
+
+        assert_eq!(latest_messages.len(), 3);
+        assert!(latest_messages.iter().any(|message| message.1.is_some()));
+
+        Ok(())
+    }
+
+    #[sqlx::test(
+        migrations = "../../db/migrations",
+        fixtures("user", "room", "messages_for_reply")
+    )]
+    pub async fn get_older_messages_with_reply_test(pool: MySqlPool) -> Result<(), sqlx::Error> {
+        let db = DB::from_pool(pool);
+        let room_id = "0";
+
+        let latest_messages = db.get_latest_messages(room_id, 1).await?;
+
+        assert!(!latest_messages.is_empty());
+
+        let latest_message = &latest_messages.last().unwrap().0;
+
+        let older_messages = db
+            .get_older_messages(room_id, latest_message.created_at, 2)
+            .await?;
+
+        assert_eq!(older_messages.len(), 2);
 
         Ok(())
     }

--- a/core/models/src/lib.rs
+++ b/core/models/src/lib.rs
@@ -70,14 +70,14 @@ pub struct CreateRoomRequest {
     pub room_name: String,
 }
 
-#[derive(sqlx::FromRow)]
+#[derive(Debug, sqlx::FromRow)]
 pub struct Participant {
     pub room_id: String,
     pub user_id: String,
     pub joined_at: DateTime<Utc>,
 }
 
-#[derive(sqlx::FromRow)]
+#[derive(Debug, sqlx::FromRow)]
 pub struct Message {
     pub id: String,
     pub room_id: String,


### PR DESCRIPTION
## issueリンク

#143 

## 概要
dbクレートに以下のメソッドを追加
- get_latest_messages
- get_older_messages
