### PR TITLE
feat: 最新のメッセージを取得するapiを実装した

### DIFF
--- a/core/chat/src/api.rs
+++ b/core/chat/src/api.rs
@@ -1,2 +1,3 @@
+pub mod message;
 pub mod room;
 pub mod user;

--- a/core/chat/src/api/message.rs
+++ b/core/chat/src/api/message.rs
@@ -1,0 +1,69 @@
+use crate::{clerk::VerifiedToken, AppState};
+use axum::{
+    extract::{Path, Query, State},
+    http::{HeaderMap, StatusCode},
+    Json,
+};
+use chrono::{DateTime, Utc};
+use db::error::IntoStatusCode as _;
+use std::{collections::HashMap, sync::Arc};
+
+#[utoipa::path(
+    get,
+    path = "/rooms/{room_id}/messages",
+    params(
+        ("room_id" = String, Path),
+        ("limit" = u32, Query),
+        ("last_created_at" = Option<DateTime<Utc>>, Query, description = "Optional timestamp to get messages before this time")
+    ),
+    summary = "Get messages in room",
+    description = "ルーム内のメッセージ一覧を取得。指定された時刻以前のメッセージを取得することも可能。",
+    responses(
+        (status = 200, description = "Success to get messages", body = Vec<models::Message>),
+        (status = 404, description = "Room not found"),
+        (status = 500, description = "Internal server error"),
+        (status = 503, description = "Failed to communicate database"),
+    ),
+    tag = "Messages"
+)]
+pub async fn get_room_messages(
+    State(state): State<Arc<AppState>>,
+    Path(room_id): Path<String>,
+    Query(params): Query<HashMap<String, String>>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<models::Message>>, StatusCode> {
+    VerifiedToken::from_headers(&headers)?.verify()?;
+
+    static DEFAULT_LIMIT: u32 = 20;
+
+    let last_created_at = params
+        .get("last_created_at")
+        .and_then(|v| serde_json::from_str::<DateTime<Utc>>(v).ok());
+
+    let limit = params
+        .get("limit")
+        .and_then(|v| serde_json::from_str::<u32>(v).ok())
+        .unwrap_or(DEFAULT_LIMIT);
+
+    let messages_with_reply = if let Some(last_created_at) = last_created_at {
+        state
+            .db
+            .lock()
+            .await
+            .get_older_messages(&room_id, limit, last_created_at)
+            .await
+            .into_statuscode()?
+    } else {
+        state
+            .db
+            .lock()
+            .await
+            .get_latest_messages(&room_id, limit)
+            .await
+            .into_statuscode()?
+    };
+
+    let messages = messages_with_reply.into_iter().map(|m| m.0).collect();
+
+    Ok(Json(messages))
+}

--- a/core/chat/src/api/room.rs
+++ b/core/chat/src/api/room.rs
@@ -69,6 +69,9 @@ pub async fn create_room(
 #[utoipa::path(
     delete,
     path = "/rooms/{room_id}",
+    params(
+        ("room_id" = String, Path)
+    ),
     summary = "Delete room",
     description = "ルームを削除",
     responses(
@@ -105,6 +108,9 @@ pub async fn delete_room(
     path = "/rooms/{room_id}",
     summary = "Update room",
     description = "ルームをアップデート",
+    params(
+        ("room_id" = String, Path)
+    ),
     request_body (content = RoomUpdate),
     responses(
         (status = 200, description = "Success to update room", body = models::Room),
@@ -148,6 +154,9 @@ pub async fn update_room(
     path = "/rooms/{room_id}/users",
     summary = "Get users in room",
     description = "ルーム内のユーザ一覧を取得",
+    params(
+        ("room_id" = String, Path)
+    ),
     responses(
         (status = 200, description = "Success to get users", body = Vec<models::User>),
         (status = 404, description = "Room not found"),

--- a/core/chat/src/api/user.rs
+++ b/core/chat/src/api/user.rs
@@ -46,6 +46,9 @@ pub async fn get_user_me(
     path = "/users/{user_id}",
     summary = "Get user by id",
     description = "IDからユーザーを取得",
+    params(
+        ("user_id" = String, Path)
+    ),
     responses(
         (status = 200, description = "Found user", body = models::User),
         (status = 404, description = "User not found"),

--- a/core/chat/src/main.rs
+++ b/core/chat/src/main.rs
@@ -5,6 +5,7 @@ mod webhook;
 mod websocket;
 
 use api::{
+    message::get_room_messages,
     room::{create_room, delete_room, get_room_users, update_room},
     user::{get_user, get_user_me, get_user_rooms},
 };
@@ -85,6 +86,7 @@ async fn main() {
         .route("/rooms/{room_id}", delete(delete_room))
         .route("/rooms/{room_id}", patch(update_room))
         .route("/rooms/{room_id}/users", get(get_room_users))
+        .route("/rooms/{room_id}/messages", get(get_room_messages))
         .route("/webhooks/user_signup", post(webhook_user_signup))
         .route("/webhooks/user_deleted", post(webhook_user_deleted))
         .route("/webhooks/user_updated", post(webhook_user_updated))
@@ -110,6 +112,7 @@ async fn main() {
         api::room::delete_room,
         api::room::update_room,
         api::room::get_room_users,
+        api::message::get_room_messages,
         webhook::webhook_user_signup,
         webhook::webhook_user_deleted,
         webhook::webhook_user_updated,

--- a/core/db/src/message.rs
+++ b/core/db/src/message.rs
@@ -167,8 +167,8 @@ impl DB {
     pub async fn get_older_messages(
         &self,
         room_id: &str,
-        last_created_at: DateTime<Utc>,
         limit: u32,
+        last_created_at: DateTime<Utc>,
     ) -> Result<Vec<(models::Message, Option<models::Message>)>, sqlx::Error> {
         let messages_with_reply = sqlx::query_as!(
             MessageWithReply,
@@ -314,7 +314,7 @@ mod test {
         let latest_message = &latest_messages.last().unwrap().0;
 
         let older_messages = db
-            .get_older_messages(room_id, latest_message.created_at, 2)
+            .get_older_messages(room_id, 2, latest_message.created_at)
             .await?;
 
         assert_eq!(older_messages.len(), 2);

--- a/core/models/src/lib.rs
+++ b/core/models/src/lib.rs
@@ -77,7 +77,7 @@ pub struct Participant {
     pub joined_at: DateTime<Utc>,
 }
 
-#[derive(Debug, sqlx::FromRow)]
+#[derive(ToSchema, Debug, Serialize, sqlx::FromRow)]
 pub struct Message {
     pub id: String,
     pub room_id: String,


### PR DESCRIPTION
## issueリンク

#145

## 概要
`{{url}}/rooms/:room_id/messages` を実装した。
クエリとして以下を指定できる。
- 'limit' 取得するメッセージの数
- 'last_created_at' これ以前のメッセージを取得する

## プレビュー
