### PR TITLE
fix: kansai-areaを送信したときに空にした

### DIFF
--- a/web/src/features/routes/chat/bottom-input.tsx
+++ b/web/src/features/routes/chat/bottom-input.tsx
@@ -63,6 +63,8 @@ export const BottomInput = memo((props: Props) => {
     ws?.send(JSON.stringify(event));
 
     props.bottomInputRef.current.value = "";
+
+    props.setInputMessage(null);
   };
 
   const changeInput = (inputMessage: string) => props.setInputMessage(inputMessage);


### PR DESCRIPTION
## issueリンク

#167 

## 概要

送信したときに関西弁翻訳エリアを空にした